### PR TITLE
Fixed a small bug which was throwing TypeError

### DIFF
--- a/easyapplybot.py
+++ b/easyapplybot.py
@@ -292,9 +292,9 @@ class EasyApplyBot:
         return page
 
     def avoid_lock(self):
-        x, _ = pyautogui.position()
-        pyautogui.moveTo(x+200, None, duration=1.0)
-        pyautogui.moveTo(x, None, duration=0.5)
+        x, y = pyautogui.position()
+        pyautogui.moveTo(x+200, y, duration=1.0)
+        pyautogui.moveTo(x, y, duration=0.5)
         pyautogui.keyDown('ctrl')
         pyautogui.press('esc')
         pyautogui.keyUp('ctrl')


### PR DESCRIPTION
In avoid_lock() function, you are passing None to moveTo() function which you actually can't, and this throws TypeError. So, I replaced None with y which is the y-coordinate of position of cursor.