### PR TITLE
Updated readme to pip3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Video: https://www.youtube.com/watch?v=4R4E304fEAs
 
 The run the bot install requirements
 ```bash
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 Enter your username, password, and search settings into the `config.yaml` file


### PR DESCRIPTION
Considering that this is using Python 3, it makes more sense to install with pip3 rather than pip, to specify that pip should run for Python 3.