### PR TITLE
Fixed "future" link problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Video: https://www.youtube.com/watch?v=4R4E304fEAs
 ## Setup 
 
 Python 3.10 using a conda virtual environment on Linux (Ubuntu)
+Install conda: https://docs.conda.io/projects/conda/en/latest/user-guide/install/linux.html
+```bash
+conda create -n easybot python=3.1o.9 anaconda
+conda activate easybot
+```
 
 The run the bot install requirements
 ```bash

--- a/README.md
+++ b/README.md
@@ -55,3 +55,13 @@ To execute the bot run the following in your terminal
 python3 easyapplybot.py
 ```
 
+## Troubleshooting
+If you get an error like this:
+```bash
+Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+```
+Add the following to your .bashrc file
+```bash
+export PATH=$PATH:/home/$USER/.local/bin
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ PyYAML~=5.3.1
 lxml
 future~=0.18.3
 bs4~=0.0.1
-future


### PR DESCRIPTION
ERROR: Double requirement given: future (from -r requirements.txt (line 10)) (already in future~=0.18.3 (from -r requirements.txt (line 8)), name='future')

Fixed this problem