### PR TITLE
remove zelle code

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,5 @@ To execute the bot run the following in your terminal
 python3 easyapplybot.py
 ```
 
-Do you like the project and find it helpful?
-Leave a tip if you'd like to support! 
-Zelle: ba2512005@gmail.com
-![zelle](https://github.com/ba2512005/LinkedIn-Easy-Apply-Bot/assets/17554729/c17006bf-d926-4d02-91ef-ac98f615f764)
 
 


### PR DESCRIPTION
Remove Zelle code from a previous PR. This zelle code doesnt seem to belong to the maintainer of the repo and was added by a PR contributor. 

Was this intentional?